### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unity-meta-check.yml
+++ b/.github/workflows/unity-meta-check.yml
@@ -12,6 +12,9 @@ on:
       - src/UniTaskPlus.Unity/Packages/**
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   meta-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AndanteTribe/UniTaskPlus/security/code-scanning/1](https://github.com/AndanteTribe/UniTaskPlus/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so all jobs inherit minimal token access.  
Best fix here: add at the workflow root (after `on:` block, before `jobs:`) with `contents: read`, which is sufficient for checkout and read-only analysis tasks and does not change intended functionality.

File to edit:
- `.github/workflows/unity-meta-check.yml`

Change:
- Insert:
  - `permissions:`
  - `  contents: read`

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
